### PR TITLE
Add the Toshiba UDF driver

### DIFF
--- a/posts/windows-software.html
+++ b/posts/windows-software.html
@@ -3578,6 +3578,11 @@
               <a href="https://oemdrivers.com/">OEM Drivers</a>
             </p>
           </li>
+          <li>
+            <p class="maintext">
+              <a href="http://web.archive.org/web/20130324210631/http://cdgenp01.csd.toshiba.com/content/support/downloads/sl25dvdramx.exe">Toshiba UDF driver (works well with DVD-RAM discs)</a>
+            </p>
+          </li>
           <p class="maintext">
             <i
               >Note: If you are having issues regarding High Definition Audio
@@ -4427,3 +4432,4 @@ https://clients2.google.com/service/update2/crx?response=redirect&prodversion=[P
     </div>
   </body>
 </html>
+


### PR DESCRIPTION
A few days ago I finally managed to install XP on my PC, and I need to use DVD-RAM discs.

I found the link on an old forum post from 2006, and thank God, it was archived on archive.org.

So, in case anyone else needs to use this clunky storage medium, here's the driver (since FAT32 is a really bad filesystem for optical discs).