### PR TITLE
Add JSFML, JDK8 and FPC

### DIFF
--- a/posts/windows-software.html
+++ b/posts/windows-software.html
@@ -2982,14 +2982,23 @@
               >
             </td>
             <td></td>
-          </tr
+          </tr>
+          <tr>
+            <td>Java Development Kit</td>
+            <td>1.8.0_152</td>
+            <td>
+              <a href="https://archive.org/download/Java-Archive/Java%20SE%208%20%288u202%20and%20earlier%29/8u152/JDK/jdk-8u152-windows-i586.exe">
+                archive.org</a>
+            </td>
+            <td>As mentioned before, has some issues running JSFML, but it's not too bad.</td>
+          </tr>
             <tr>
               <td>JSFML</td>
               <td>2.2</td>
               <td>
                 <a href="https://codeberg.org/glowiak/mmc-fbsd-bins/releases/download/jsfml-2.2/jsfml.jar">jsfml.jar</a>, 
                 <a href="https://jsfml.sfmlprojects.org/">Homepage</a>
-              </td
+              </td>
                 <td>
                   A Java binding of the SFML graphics library. The JVM segfaults when quitting a game that utilizes sound, but so far it hasn't been proved harmful.
                 </td>
@@ -4443,5 +4452,6 @@ https://clients2.google.com/service/update2/crx?response=redirect&prodversion=[P
     </div>
   </body>
 </html>
+
 
 

--- a/posts/windows-software.html
+++ b/posts/windows-software.html
@@ -3003,6 +3003,18 @@
                   A Java binding of the SFML graphics library. The JVM segfaults when quitting a game that utilizes sound, but so far it hasn't been proved harmful.
                 </td>
             </tr>
+          <tr>
+            <td>Free Pascal</td>
+            <td>2.6.4</td>
+            <td>
+              <a href="https://sourceforge.net/projects/freepascal/files/Win32/2.6.4/fpc-2.6.4.i386-win32.exe/download">sf.net</a>, 
+              <a href="https://www.freepascal.org">Homepage</a>
+            </td>
+            <td>
+              Includes bindings for SDL 1.2. Used by Bad Sector in the 
+              <a href="https://www.youtube.com/watch?v=hPmJB0mS-GA">Making a game in Free Pascal</a> video.
+            </td>
+          </tr>
         </table>
         <br />
         <p class="maintext-bold" id="microsoft-software">Microsoft Software</p>
@@ -4452,6 +4464,7 @@ https://clients2.google.com/service/update2/crx?response=redirect&prodversion=[P
     </div>
   </body>
 </html>
+
 
 
 

--- a/posts/windows-software.html
+++ b/posts/windows-software.html
@@ -2982,7 +2982,18 @@
               >
             </td>
             <td></td>
-          </tr>
+          </tr
+            <tr>
+              <td>JSFML</td>
+              <td>2.2</td>
+              <td>
+                <a href="https://codeberg.org/glowiak/mmc-fbsd-bins/releases/download/jsfml-2.2/jsfml.jar">jsfml.jar</a>, 
+                <a href="https://jsfml.sfmlprojects.org/">Homepage</a>
+              </td
+                <td>
+                  A Java binding of the SFML graphics library. The JVM segfaults when quitting a game that utilizes sound, but so far it hasn't been proved harmful.
+                </td>
+            </tr>
         </table>
         <br />
         <p class="maintext-bold" id="microsoft-software">Microsoft Software</p>
@@ -4432,4 +4443,5 @@ https://clients2.google.com/service/update2/crx?response=redirect&prodversion=[P
     </div>
   </body>
 </html>
+
 


### PR DESCRIPTION
JSFML is a very nice binding of the SFML graphics library to Java. It's been wonderfully outdated, since this version was released in 2013, when XP was still supported.

I found this thingy when I was frustrated with C++'s hidden allocations, and I liked it. It requires far less boilerplate code than SDL, and unlike raylib it has proper support for fonts.

The JVM segfaults when quitting a game that plays sound, but that doesn't seem to affect the game or the system whatsoever. This seems to happen solely on the Windows XP version of Java 8 (JSFML also supports Java 7 by the way), and doesn't happen on my way newer Java on Slackware 15.

Also, github sucks. When I wanted to commit these changes, the whole page froze for half a minute (I'm writing this from Mypal68 on WinXP) because this shitty piece of garbage nobody asked for wanted to slopify some slop for the description.